### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/Projects/Frontend/Config/Storage.php
+++ b/Projects/Frontend/Config/Storage.php
@@ -98,7 +98,7 @@
             ],
             'redis' =>
             [
-                'password' => NULL,
+                'password' => null,
                 'host'     => '127.0.0.1',
                 'port'     => 6379,
                 'timeout'  => 0

--- a/Projects/Frontend/Config/ViewObjects.php
+++ b/Projects/Frontend/Config/ViewObjects.php
@@ -37,7 +37,7 @@
         'firstName'     => '&laquo;&laquo;',
         'lastName'      => '&raquo;&raquo;',
         'totalRows'     => 50,
-        'start'         => NULL,
+        'start'         => null,
         'limit'         => 10,
         'countLinks'    => 10,
         'type'          => 'classic', # classic, ajax


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!